### PR TITLE
Update Play/Pause functionality

### DIFF
--- a/consolify_pkgs/commands.py
+++ b/consolify_pkgs/commands.py
@@ -97,18 +97,50 @@ What would you like to do? You could say: 'play', 'back' or 'add queue'
 
 
 def pause():
-    if sp.current_playback() is not None:
-        sp.pause_playback()
-        print("Paused")
+    current_playback = sp.current_playback()
+    
+    if current_playback is not None:
+        # Check if Spotify is already paused
+        if current_playback.get('is_playing', False):
+            sp.pause_playback()
+            print("Paused")
+        else: 
+            print("Spotify is already paused.")
     else:
         print("Can't pause, there is nothing playing.")
 
 
 def play():
-    recently_played = sp.current_user_recently_played(limit=10)
-    if recently_played and 'items' in recently_played:
-        track_uris = [item['track']['uri'] for item in recently_played['items']]
-        sp.start_playback(uris=[track_uris[0]])
-        print(f"Playing the most recently played track: {recently_played['items'][0]['track']['name']}")
+    current_playback = sp.current_playback()
+
+    # Resume playback if there is a current playback
+    if current_playback is not None:
+        if current_playback.get('is_playing', False):
+            print("Spotify is already playing.")
+        else: 
+            print("Resuming playback.")
+            sp.start_playback()
+    # Play recently played songs if there is no current playback
     else:
-        print("No recently played tracks found.")
+        recently_played = sp.current_user_recently_played(limit=10)
+
+        # Check if there are recently played songs
+        if recently_played and 'items' in recently_played:
+            # Get the track URIs from the recently played songs
+            track_uris = [item['track']['uri'] for item in recently_played['items']]
+
+            # Choose a device for playback
+            device_id = choose_device()
+
+            # Check if the user chose to go back or no device was selected
+            if device_id == "back":
+                return "back"
+            elif device_id is None:
+                print("Playback aborted.")
+                return
+
+            # Start playback with the most recently played tracks on the chosen device
+            sp.start_playback(uris=track_uris, device_id=device_id)
+            print(f"Playing the most recently played track: {recently_played['items'][0]['track']['name']}")
+        else:
+            print("No recently played tracks found.")


### PR DESCRIPTION
Added functionality to "play" command: 

- play will now resume playback if a song is paused
- if no song is playing, it will prompt for device then play the most recent 10 tracks for that device 
- will let the user know if a song is already playing 

Added fix to "pause" command to prevent errors if music is already paused. 

*note: this is my first ever pull request, so please let me know if there's anything I can improve on. Thanks! 